### PR TITLE
fix: restricted nil or empty value assign of userId for identify calls

### DIFF
--- a/Assets/RudderStack/RudderAnalytics SDK/Scripts/RSClient.cs
+++ b/Assets/RudderStack/RudderAnalytics SDK/Scripts/RSClient.cs
@@ -103,7 +103,7 @@ namespace RudderStack.Unity
 
         public void Identify(string userId, IDictionary<string, object> traits, RSOptions options)
         {
-            if (string.IsNullOrEmpty(userId) && string.IsNullOrEmpty(AnonymousId))
+            if (string.IsNullOrEmpty(userId))
             {
                 Logger.Error("Please supply a valid userId to Identify.");
                 return;


### PR DESCRIPTION
### Description

> Identify call is accepting nill or empty userId